### PR TITLE
Move prettier into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "lodash": "^4.17.21",
     "md5": "^2.3.0",
     "moize": "^6.1.0",
-    "prettier": "^2.5.1",
     "temp-dir": "^3.0.0",
     "ts-essentials": "^8.1.0"
   },
@@ -85,6 +84,7 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.3.1",
     "tsup": "^6.5.0",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.4",
+    "prettier": "^2.5.1"
   }
 }


### PR DESCRIPTION
I was checking the metro bundle and saw prettier code there. I removed prettier from my project and noticed that prettier code was still there. After checking `npm why prettier` it showed `graphql-ts-client` as source of usage.

