### PR TITLE
Include __headers, __retry and __alias to all GraphQL endpoints

### DIFF
--- a/src/generateTypescriptClient.test.ts
+++ b/src/generateTypescriptClient.test.ts
@@ -20,13 +20,25 @@ describe('Generated Client', () => {
       // specify an output path
       output: path.resolve(__dirname, './__testClient.ts'),
       formatGraphQL: true,
-      skipCache: true
+      skipCache: true,
     })
 
     client = eval(`${js};${clientName}`)
   })
 
   afterAll(async () => await testServer.server.stop())
+
+  it('should be able to pass custom headers to a query without args', async () => {
+    const books = await client.queries.booksWithoutParams({
+      __headers: { 'X-Custom-Header': 'Foo' },
+      title: true,
+      author: true,
+    })
+
+    expect(books).toHaveLength(2)
+    expect(books[0]).toHaveProperty('title')
+    expect(books[0]).toHaveProperty('author')
+  })
 
   it('should be able to make queries with optional args, not passing args obj', async () => {
     // noinspection TypeScriptValidateJSTypes
@@ -112,5 +124,4 @@ describe('Generated Client', () => {
     expect(responseData?.queryName).toBe('failingQuery')
     expect(responseData?.response.errors.length).toBeGreaterThan(0)
   })
-
 })

--- a/src/generateTypescriptClient.ts
+++ b/src/generateTypescriptClient.ts
@@ -135,24 +135,21 @@ function getArgsType(endpoint: IntrospectionField) {
 }
 
 function gqlEndpointToCode(kind: 'mutation' | 'query', endpoint: IntrospectionField, codeOutputType: 'ts' | 'js'): string {
-  let selectionType = gqlTypeToTypescript(endpoint.type, {
+  const selectionType = gqlTypeToTypescript(endpoint.type, {
     isInput: false,
     selection: true,
   })
 
-  if (endpoint.args && endpoint.args.length) {
-    const argsType = getArgsType(endpoint)
-    selectionType = `{ 
-      __headers?: {[key: string]: string}; 
-      __retry?: boolean; 
-      __alias?: string; 
-      __args${argsType.optional ? '?' : ''}: ${argsType.alias}
-    }${selectionType ? ` & ${selectionType}` : ''}`
-  }
+  const argsType = endpoint.args && endpoint.args.length ? getArgsType(endpoint) : null
+  const inputType = `{
+    __headers?: {[key: string]: string};
+    __retry?: boolean;
+    __alias?: string;
+    ${argsType ? `__args${argsType.optional ? '?' : ''}: ${argsType.alias}` : ''}
+  }${selectionType ? ` & ${selectionType}` : ''}`
 
   const outputType = gqlTypeToTypescript(endpoint.type, { required: true })
   const wrappedOutputType = /^(string|number|boolean)$/.test(outputType) ? outputType : `DeepRequired<${outputType}>`
-  const inputType = selectionType || 'undefined'
 
   return codeOutputType === 'ts'
     ? `${endpoint.name}: Endpoint<${inputType}, ${wrappedOutputType}, AllEnums>`

--- a/src/testServer.ts
+++ b/src/testServer.ts
@@ -28,6 +28,7 @@ const typeDefs = gql`
   }
 
   type Query {
+    booksWithoutParams: [Book]
     booksWithOptionalParams(params: BookSearchParamsAllOptional! = {}): [Book]
     booksWithRequiredParams(params: BookSearchParamsSomeRequired!): [Book]
     failingQuery(id: String!): String
@@ -53,6 +54,7 @@ function filterBooks(params: { title?: string; author?: string }) {
 
 const resolvers = {
   Query: {
+    booksWithoutParams: () => books,
     booksWithOptionalParams: (_: any, { params = {} }: { params: { title?: string; author?: string } }) => filterBooks(params),
     booksWithRequiredParams: (_: any, { params }: { params: { title: string; author?: string } }) => filterBooks(params),
     failingQuery: () => {
@@ -63,7 +65,7 @@ const resolvers = {
 
 const testServer = new ApolloServer({
   typeDefs,
-  resolvers
+  resolvers,
 })
 
 export const startServer = () => testServer.listen(4123).then(({ url }) => ({ url, server: testServer }))


### PR DESCRIPTION
There is an issue with the GraphQL endpoints without arguments where it's not possible to set custom headers without having to set it for the whole client.

This PR adds not only the `__headers` to a single endpoint, but also `__retry` and `__alias`